### PR TITLE
Fix #34 - A single-constructor, multiple-arg type cannot have a newtype.

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -269,6 +269,25 @@ allTests =
                           , "--------------------------------------------------------------------------------"
                           ]
       in recTypeText `shouldBe` txt
+    it "tests generation for haskell data type with one constructor, two arguments" $
+      let recType = bridgeSumType (buildBridge defaultBridge) (mkSumType (Proxy :: Proxy SingleProduct))
+          recTypeText = sumTypeToText recType
+          txt = T.stripEnd $
+                T.unlines [ "data SingleProduct ="
+                          , "    SingleProduct String Int"
+                          , ""
+                          , "derive instance genericSingleProduct :: Generic SingleProduct"
+                          , ""
+                          , ""
+                          , "--------------------------------------------------------------------------------"
+                          , "_SingleProduct :: Prism' SingleProduct { a :: String, b :: Int }"
+                          , "_SingleProduct = prism' (\\{ a, b } -> SingleProduct a b) f"
+                          , "  where"
+                          , "    f (SingleProduct a b) = Just $ { a: a, b: b }"
+                          , ""
+                          , "--------------------------------------------------------------------------------"
+                          ]
+      in recTypeText `shouldBe` txt
     it "tests that sum types with multiple constructors don't generate record optics" $
       let recType = bridgeSumType (buildBridge defaultBridge) (mkSumType (Proxy :: Proxy TwoRecords))
           recTypeOptics = recordOptics recType

--- a/test/TestData.hs
+++ b/test/TestData.hs
@@ -66,6 +66,9 @@ newtype SomeNewtype = SomeNewtype Int
 data SingleValueConstr = SingleValueConstr Int
   deriving (Generic, Typeable, Show)
 
+data SingleProduct = SingleProduct Text Int
+  deriving (Generic, Typeable, Show)
+
 a :: HaskellType
 a = mkTypeInfo (Proxy :: Proxy (Either String Int))
 


### PR DESCRIPTION
The newtype generation rules were wrong for a type like:

``` haskell
data data SingleProduct =
  SingleProduct String Int
```

We were attempting to generate an Iso to a Newtype instance. Fixed.