### PR TITLE
Prim module in Purescript is build in 

### DIFF
--- a/src/Language/PureScript/Bridge/PSTypes.hs
+++ b/src/Language/PureScript/Bridge/PSTypes.hs
@@ -18,11 +18,11 @@ import           Language.PureScript.Bridge.TypeInfo
 
 -- | Uses  type parameters from 'haskType' (bridged).
 psArray :: MonadReader BridgeData m => m PSType
-psArray = TypeInfo "purescript-prim" "Prim" "Array" <$> psTypeParameters
+psArray = TypeInfo "" "Prim" "Array" <$> psTypeParameters
 
 psBool :: PSType
 psBool = TypeInfo {
-    _typePackage = "purescript-prim"
+    _typePackage = ""
   , _typeModule = "Prim"
   , _typeName = "Boolean"
   , _typeParameters = []
@@ -34,7 +34,7 @@ psEither = TypeInfo "purescript-either" "Data.Either" "Either" <$> psTypeParamet
 
 psInt :: PSType
 psInt = TypeInfo {
-    _typePackage = "purescript-prim"
+    _typePackage = ""
   , _typeModule = "Prim"
   , _typeName = "Int"
   , _typeParameters = []
@@ -42,7 +42,7 @@ psInt = TypeInfo {
 
 psNumber :: PSType
 psNumber = TypeInfo {
-    _typePackage = "purescript-prim"
+    _typePackage = ""
   , _typeModule = "Prim"
   , _typeName = "Number"
   , _typeParameters = []
@@ -54,7 +54,7 @@ psMaybe = TypeInfo "purescript-maybe" "Data.Maybe" "Maybe" <$> psTypeParameters
 
 psString :: PSType
 psString = TypeInfo {
-    _typePackage = "purescript-prim"
+    _typePackage = ""
   , _typeModule = "Prim"
   , _typeName = "String"
   , _typeParameters = []

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -27,7 +27,7 @@ allTests =
   describe "buildBridge" $ do
     it "tests with Int" $
       let bst = buildBridge defaultBridge (mkTypeInfo (Proxy :: Proxy Int))
-          ti  = TypeInfo { _typePackage    = "purescript-prim"
+          ti  = TypeInfo { _typePackage    = ""
                        , _typeModule     = "Prim"
                        , _typeName       = "Int"
                        , _typeParameters = []}
@@ -40,12 +40,12 @@ allTests =
                 [ DataConstructor { _sigConstructor = "Foo" , _sigValues = Left [] }
                 , DataConstructor
                   { _sigConstructor = "Bar"
-                  , _sigValues = Left [ TypeInfo { _typePackage = "purescript-prim" , _typeModule = "Prim" , _typeName = "Int" , _typeParameters = [] } ]
+                  , _sigValues = Left [ TypeInfo { _typePackage = "" , _typeModule = "Prim" , _typeName = "Int" , _typeParameters = [] } ]
                   }
                 , DataConstructor
                   { _sigConstructor = "FooBar"
-                  , _sigValues = Left [ TypeInfo { _typePackage = "purescript-prim" , _typeModule = "Prim" , _typeName = "Int" , _typeParameters = [] }
-                                      , TypeInfo { _typePackage = "purescript-prim" , _typeModule = "Prim" , _typeName = "String" , _typeParameters = [] }
+                  , _sigValues = Left [ TypeInfo { _typePackage = "" , _typeModule = "Prim" , _typeName = "Int" , _typeParameters = [] }
+                                      , TypeInfo { _typePackage = "" , _typeModule = "Prim" , _typeName = "String" , _typeParameters = [] }
                                       ]
                   }
                 ]


### PR DESCRIPTION
in pursescript 0.11.7 there is no more external purescript-prim dependency for the Prim module

clearing out the references to purescript-prim