### PR TITLE
`unwrapSingleArguments` switch; improvements to example

### DIFF
--- a/example/app/GeneratePurescript.hs
+++ b/example/app/GeneratePurescript.hs
@@ -16,7 +16,7 @@ frontEndRoot = "src"
 main :: IO ()
 main = do
   writePSTypesWith
-    (useGenRep <> genForeign (ForeignOptions False))
+    (useGenRep <> genForeign (ForeignOptions False False))
     frontEndRoot
     (buildBridge myBridge)
     myTypes

--- a/example/example.cabal
+++ b/example/example.cabal
@@ -12,7 +12,9 @@ library
   exposed-modules:     MyLib, Types
   hs-source-dirs:      src
   build-depends:       base >=4.8 && <5
-                     , aeson
+                     , aeson >= 1.5.5.0
+                     , aeson-pretty
+                     , bytestring
                      , lens
                      , transformers
                      , servant >=0.18.0

--- a/example/readme.md
+++ b/example/readme.md
@@ -17,13 +17,13 @@ In this directory:
 - Open the browser's developer console and look for the message received:
 
 ```
-Foo message: Hello	 Foo number: 123
+Foo message: Hello	 Foo number: 123    Foo list length: 11
 ```
 
 - Look at the server's logs for the message sent from the browser:
 
 ```
-Foo message: Hola        Foo number: 124
+Foo message: Hola        Foo number: 124        Foo list length: 22
 ```
 
 ----------------

--- a/example/src/Main.purs
+++ b/example/src/Main.purs
@@ -8,6 +8,7 @@ import Data.Argonaut.Aeson.Options (defaultOptions)
 import Data.Either (Either(Left, Right))
 import Data.Maybe (Maybe(Just))
 import Data.Lens (over, view, set)
+import Data.Foldable (length)
 import Data.Traversable (for_)
 import Effect (Effect)
 import Effect.Console (log)
@@ -17,7 +18,7 @@ import Affjax (get, post_)
 import Affjax.ResponseFormat (json)
 import Affjax.RequestBody as RequestBody
 
-import Types (Foo, fooMessage, fooNumber)
+import Types (Foo, fooMessage, fooNumber, fooList)
 
 main :: Effect Unit
 main = log "Hello, Purescript!" *> launchAff_ do
@@ -37,9 +38,14 @@ main = log "Hello, Purescript!" *> launchAff_ do
       liftEffect do
         log $ "Foo message: " <> (view fooMessage foo)
           <> "\t Foo number: " <> (show $ view fooNumber foo)
+          <> "\t Foo list length: "
+          <> (show (length $ view fooList foo :: Int))
       let
         -- modify the Foo received and send it back
-        foo' = set fooMessage "Hola" $ over fooNumber (_+1) foo
+        foo' = set fooMessage "Hola"
+               $ over fooNumber (_+1)
+               $ over fooList (\l -> l <> l)
+               $ foo
         response = Just $ RequestBody.json $ genericEncodeAeson defaultOptions foo'
       post_ "/foo" response
 

--- a/example/src/Main.purs
+++ b/example/src/Main.purs
@@ -5,7 +5,7 @@ import Prelude
 import Data.Argonaut.Aeson.Decode.Generic (genericDecodeAeson)
 import Data.Argonaut.Aeson.Encode.Generic (genericEncodeAeson)
 import Data.Argonaut.Aeson.Options (defaultOptions)
-import Data.Either (Either)
+import Data.Either (Either(Left, Right))
 import Data.Maybe (Maybe(Just))
 import Data.Lens (over, view, set)
 import Data.Traversable (for_)
@@ -21,16 +21,25 @@ import Types (Foo, fooMessage, fooNumber)
 
 main :: Effect Unit
 main = log "Hello, Purescript!" *> launchAff_ do
+  -- "Foo" tests untagged JSON, i.e.:
+  -- { "_fooMessage": "Hello", "_fooNumber": 123 }
+
+  -- request a Foo
   fooResponse <- get json "/foo"
   for_ fooResponse \fooPayload -> do
     let
       efoo :: Either String Foo
       efoo = genericDecodeAeson defaultOptions fooPayload.body
+    case efoo of
+      Left e -> liftEffect $ log $ "Error decoding Foo: " <> e
+      Right _ -> pure unit
     for_ efoo \foo -> do
       liftEffect do
         log $ "Foo message: " <> (view fooMessage foo)
           <> "\t Foo number: " <> (show $ view fooNumber foo)
       let
+        -- modify the Foo received and send it back
         foo' = set fooMessage "Hola" $ over fooNumber (_+1) foo
         response = Just $ RequestBody.json $ genericEncodeAeson defaultOptions foo'
       post_ "/foo" response
+

--- a/example/src/MyLib.hs
+++ b/example/src/MyLib.hs
@@ -1,32 +1,38 @@
-{-# LANGUAGE DataKinds      #-}
-{-# LANGUAGE TypeOperators  #-}
+{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE TypeOperators #-}
 
 
 module MyLib (main) where
 
 import Prelude
 
-import Control.Lens (view)
-import Control.Monad.IO.Class (liftIO)
-import Data.Aeson
-import Data.Text (pack, unpack)
-import GHC.Generics
-import GHC.TypeLits
-import Network.Wai.Handler.Warp
-import Servant
-import System.Environment (lookupEnv)
+import           Control.Lens (view)
+import           Control.Monad.IO.Class (liftIO)
+import           Data.Aeson
+import qualified Data.Aeson.Encode.Pretty as AP
+import qualified Data.ByteString.Lazy.Char8 as Char8
+import           Data.Text (pack, unpack)
+import           GHC.Generics
+import           GHC.TypeLits
+import           Network.Wai.Handler.Warp
+import           Servant
+import           System.Environment (lookupEnv)
 
-import Types (Foo(Foo), fooMessage, fooNumber)
+import Types
+    (Foo (Foo), fooMessage, fooNumber)
 
 type FooServer
   = "foo" :> (Get '[JSON] Foo
               :<|> ReqBody '[JSON] Foo :> Post '[JSON] NoContent
              )
 
+foo :: Foo
+foo = Foo (pack "Hello") 123
+
 fooServer :: Server FooServer
 fooServer = getFoo :<|> postFoo
   where
-    getFoo = return $ Foo (pack "Hello") 123
+    getFoo = return foo
     postFoo foo = do
       let
         logMsg = "Foo message: " <> (unpack $ view fooMessage foo)
@@ -43,4 +49,8 @@ api :: Proxy ExampleServer
 api = Proxy
 
 main :: IO ()
-main = run 8080 . serve api $ fooServer :<|> staticServer
+main = do
+  putStrLn "Serving Foo:"
+  Char8.putStrLn $ AP.encodePretty foo
+
+  run 8080 . serve api $ fooServer :<|> staticServer

--- a/example/src/MyLib.hs
+++ b/example/src/MyLib.hs
@@ -19,7 +19,7 @@ import           Servant
 import           System.Environment (lookupEnv)
 
 import Types
-    (Foo (Foo), fooMessage, fooNumber)
+    (Foo (Foo), fooMessage, fooNumber, fooList)
 
 type FooServer
   = "foo" :> (Get '[JSON] Foo
@@ -27,7 +27,7 @@ type FooServer
              )
 
 foo :: Foo
-foo = Foo (pack "Hello") 123
+foo = Foo (pack "Hello") 123 [10..20]
 
 fooServer :: Server FooServer
 fooServer = getFoo :<|> postFoo
@@ -37,6 +37,7 @@ fooServer = getFoo :<|> postFoo
       let
         logMsg = "Foo message: " <> (unpack $ view fooMessage foo)
           <> "\t Foo number: " <> (show (view fooNumber foo))
+          <> "\t Foo list length: " <> (show . length $ view fooList foo)
       liftIO . putStrLn $ logMsg
       return NoContent
 

--- a/example/src/Types.hs
+++ b/example/src/Types.hs
@@ -18,6 +18,7 @@ import Language.PureScript.Bridge.PSTypes
 data Foo = Foo
   { _fooMessage :: Text
   , _fooNumber  :: Int
+  , _fooList    :: [Int]
   } deriving (Generic, ToJSON, FromJSON)
 
 makeLenses ''Foo

--- a/example/src/Types.purs
+++ b/example/src/Types.purs
@@ -10,7 +10,7 @@ import Data.Newtype (class Newtype)
 import Data.Symbol (SProxy(SProxy))
 import Foreign.Class (class Decode, class Encode)
 import Foreign.Generic (defaultOptions, genericDecode, genericEncode)
-import Prim (Int, String)
+import Prim (Array, Int, String)
 
 import Prelude
 
@@ -18,6 +18,7 @@ newtype Foo =
     Foo {
       _fooMessage :: String
     , _fooNumber :: Int
+    , _fooList :: Array Int
     }
 
 instance encodeFoo :: Encode Foo where
@@ -28,7 +29,7 @@ derive instance genericFoo :: Generic Foo _
 derive instance newtypeFoo :: Newtype Foo _
 
 --------------------------------------------------------------------------------
-_Foo :: Iso' Foo { _fooMessage :: String, _fooNumber :: Int}
+_Foo :: Iso' Foo { _fooMessage :: String, _fooNumber :: Int, _fooList :: Array Int}
 _Foo = _Newtype
 
 fooMessage :: Lens' Foo String
@@ -36,5 +37,8 @@ fooMessage = _Newtype <<< prop (SProxy :: SProxy "_fooMessage")
 
 fooNumber :: Lens' Foo Int
 fooNumber = _Newtype <<< prop (SProxy :: SProxy "_fooNumber")
+
+fooList :: Lens' Foo (Array Int)
+fooList = _Newtype <<< prop (SProxy :: SProxy "_fooList")
 
 --------------------------------------------------------------------------------

--- a/example/src/Types.purs
+++ b/example/src/Types.purs
@@ -21,9 +21,9 @@ newtype Foo =
     }
 
 instance encodeFoo :: Encode Foo where
-  encode = genericEncode $ defaultOptions { unwrapSingleConstructors = false }
+  encode = genericEncode $ defaultOptions { unwrapSingleConstructors = false , unwrapSingleArguments = false }
 instance decodeFoo :: Decode Foo where
-  decode = genericDecode $ defaultOptions { unwrapSingleConstructors = false }
+  decode = genericDecode $ defaultOptions { unwrapSingleConstructors = false , unwrapSingleArguments = false }
 derive instance genericFoo :: Generic Foo _
 derive instance newtypeFoo :: Newtype Foo _
 

--- a/src/Language/PureScript/Bridge/CodeGenSwitches.hs
+++ b/src/Language/PureScript/Bridge/CodeGenSwitches.hs
@@ -25,6 +25,7 @@ data Settings = Settings
 
 data ForeignOptions = ForeignOptions
     { unwrapSingleConstructors :: Bool
+    , unwrapSingleArguments    :: Bool
     }
     deriving (Eq, Show)
 


### PR DESCRIPTION
This PR adds the `unwrapSingleArguments` switch:
https://github.com/eskimor/purescript-bridge/blob/87d583f337ebf684a2b51ae0df3920163bd0870c/src/Language/PureScript/Bridge/CodeGenSwitches.hs#L26-L30

, corresponding to: https://github.com/paf31/purescript-foreign-generic/blob/46f09996bd54efc146bc1725783789dbac7d6a5b/src/Foreign/Generic/Class.purs#L37-L42


It appears in the generated Purescript:
https://github.com/eskimor/purescript-bridge/blob/87d583f337ebf684a2b51ae0df3920163bd0870c/example/src/Types.purs#L23-L26

Some improvements are made to the example.  An error is printed if decoding fails.