### PR TITLE
CI coverage for both Haskell and Purescript

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,10 +1,10 @@
 # modified from https://github.com/jgm/pandoc/blob/master/.github/workflows/ci.yml
-name: CI tests
+name: Haskell library and example
 
 on:
   push:
     branches:
-    - '*'
+    - '**'
     paths-ignore: []
   pull_request:
     paths-ignore: []
@@ -63,10 +63,10 @@ jobs:
     - name: Install dependencies
       run: |
           cabal update
-          cabal build --dependencies-only --enable-tests --disable-optimization
+          cabal build all --dependencies-only --enable-tests --disable-optimization
     - name: Build
       run: |
-          cabal build --enable-tests --disable-optimization 2>&1 | tee build.log
+          cabal build all --enable-tests --disable-optimization 2>&1 | tee build.log
     - name: Test
       run: |
-          cabal test --disable-optimization
+          cabal test all --disable-optimization

--- a/.github/workflows/purescript.yml
+++ b/.github/workflows/purescript.yml
@@ -1,0 +1,45 @@
+# adapted from https://github.com/purescript-contrib/purescript-argonaut-generic/blob/d211820cfec5c7cf2caa20dc6dc293671949b55c/.github/workflows/ci.yml
+name: Purescript example
+
+on:
+  push:
+    branches:
+    - '**'
+    paths-ignore: []
+  pull_request:
+    paths-ignore: []
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: ./example
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up a PureScript toolchain
+        uses: purescript-contrib/setup-purescript@main
+        with: # https://github.com/purescript-contrib/setup-purescript#specify-versions
+          purescript: "0.13.8"
+
+      - name: Cache PureScript dependencies
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-spago-${{ hashFiles('**/*.dhall') }}
+          path: |
+            .spago
+            output
+
+      - name: Install dependencies
+        run: spago install
+
+      - name: Build source
+        run: spago build --no-install
+
+      - name: Bundle app
+        run: spago bundle-app --to static/index.js
+
+      - name: Run tests
+        run: spago test --no-install

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # purescript-bridge
 
 
+![Haskell library and example](https://github.com/eskimor/purescript-bridge/workflows/haskell.yml/badge.svg)
+
+![Purescript example](https://github.com/eskimor/purescript-bridge/workflows/purescript.yml/badge.svg)
+
 [![Build Status](https://travis-ci.org/eskimor/purescript-bridge.svg?branch=master)](https://travis-ci.org/eskimor/purescript-bridge)
 
 


### PR DESCRIPTION
CI now tests the Purescript produced by the example.

The badges in the readme do not appear, yet.  I expect them to work if this is merged.  https://docs.github.com/en/actions/managing-workflow-runs/adding-a-workflow-status-badge

Thanks!