### PR TITLE
update `purescript-argonaut-aeson-generic`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ For compatible JSON representations:
 * On Haskell side:
   * Use [`aeson`](http://hackage.haskell.org/package/aeson)'s generic encoding/decoding with default options
 * On Purescript side:
-  * Use [`purescript-argonaut-aeson-generic`](https://pursuit.purescript.org/packages/purescript-argonaut-aeson-generic). 
-    * [This branch](https://github.com/coot/purescript-argonaut-aeson-generic/pull/17) is updated for Purescript 0.15.
+  * Use [`purescript-argonaut-aeson-generic >=0.4.1`](https://pursuit.purescript.org/packages/purescript-argonaut-aeson-generic/0.4.1) ([GitHub](https://github.com/coot/purescript-argonaut-aeson-generic))
   * Or use [`purescript-foreign-generic`](https://pursuit.purescript.org/packages/purescript-foreign-generic).
     * [This branch](https://github.com/paf31/purescript-foreign-generic/pull/76) is updated for Purescript 0.15.
 

--- a/example/packages.dhall
+++ b/example/packages.dhall
@@ -14,8 +14,8 @@ let additions =
           , "test-unit"
           ]
         , repo =
-            "https://github.com/bentongxyz/purescript-argonaut-aeson-generic.git"
-        , version = "dcd925179b37a2ac749b7a1f1ae72bb69746d886"
+            "https://github.com/coot/purescript-argonaut-aeson-generic.git"
+        , version = "v0.4.1"
         }
       , foreign-generic =
         { dependencies =

--- a/example/readme.md
+++ b/example/readme.md
@@ -1,6 +1,6 @@
 # Purescript Bridge example
 
-This project demonstrates the libraries Purescript Bridge and [Purescript Argonaut Aeson Generic](https://github.com/coot/purescript-argonaut-aeson-generic).
+This project demonstrates the libraries Purescript Bridge and [`purescript-argonaut-aeson-generic`](https://pursuit.purescript.org/packages/purescript-argonaut-aeson-generic) ([GitHub](https://github.com/coot/purescript-argonaut-aeson-generic)).
 
 It needs Purescript 0.15.
 


### PR DESCRIPTION
The library has not changed; the version already used has been published to Pursuit: https://pursuit.purescript.org/packages/purescript-argonaut-aeson-generic/0.4.1