### PR TITLE
Stylish Haskell

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,481 @@
+# stylish-haskell configuration file
+# ==================================
+
+# The stylish-haskell tool is mainly configured by specifying steps. These steps
+# are a list, so they have an order, and one specific step may appear more than
+# once (if needed). Each file is processed by these steps in the given order.
+steps:
+  # Convert some ASCII sequences to their Unicode equivalents. This is disabled
+  # by default.
+  # - unicode_syntax:
+  #     # In order to make this work, we also need to insert the UnicodeSyntax
+  #     # language pragma. If this flag is set to true, we insert it when it's
+  #     # not already present. You may want to disable it if you configure
+  #     # language extensions using some other method than pragmas. Default:
+  #     # true.
+  #     add_language_pragma: true
+
+  # Format module header
+  #
+  # Currently, this option is not configurable and will format all exports and
+  # module declarations to minimize diffs
+  #
+  # - module_header:
+  #     # How many spaces use for indentation in the module header.
+  #     indent: 4
+  #
+  #     # Should export lists be sorted?  Sorting is only performed within the
+  #     # export section, as delineated by Haddock comments.
+  #     sort: true
+  #
+  #     # See `separate_lists` for the `imports` step.
+  #     separate_lists: true
+  #
+  #     # When to break the "where".
+  #     # Possible values:
+  #     # - exports: only break when there is an explicit export list.
+  #     # - single: only break when the export list counts more than one export.
+  #     # - inline: only break when the export list is too long. This is
+  #     #   determined by the `columns` setting. Not applicable when the export
+  #     #   list contains comments as newlines will be required.
+  #     # - always: always break before the "where".
+  #     break_where: exports
+  #
+  #     # Where to put open bracket
+  #     # Possible values:
+  #     # - same_line: put open bracket on the same line as the module name, before the
+  #     #              comment of the module
+  #     # - next_line: put open bracket on the next line, after module comment
+  #     open_bracket: next_line
+
+  # Format record definitions. This is disabled by default.
+  #
+  # You can control the layout of record fields. The only rules that can't be configured
+  # are these:
+  #
+  # - "|" is always aligned with "="
+  # - "," in fields is always aligned with "{"
+  # - "}" is likewise always aligned with "{"
+  #
+  # - records:
+  #     # How to format equals sign between type constructor and data constructor.
+  #     # Possible values:
+  #     # - "same_line" -- leave "=" AND data constructor on the same line as the type constructor.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of the next line.
+  #     equals: "indent 2"
+  #
+  #     # How to format first field of each record constructor.
+  #     # Possible values:
+  #     # - "same_line" -- "{" and first field goes on the same line as the data constructor.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of the data constructor
+  #     first_field: "indent 2"
+  #
+  #     # How many spaces to insert between the column with "," and the beginning of the comment in the next line.
+  #     field_comment: 2
+  #
+  #     # How many spaces to insert before "deriving" clause. Deriving clauses are always on separate lines.
+  #     deriving: 2
+  #
+  #     # How many spaces to insert before "via" clause counted from indentation of deriving clause
+  #     # Possible values:
+  #     # - "same_line" -- "via" part goes on the same line as "deriving" keyword.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of "deriving" keyword.
+  #     via: "indent 2"
+  #
+  #     # Sort typeclass names in the "deriving" list alphabetically.
+  #     sort_deriving: true
+  #
+  #     # Whether or not to break enums onto several lines
+  #     #
+  #     # Default: false
+  #     break_enums: false
+  #
+  #     # Whether or not to break single constructor data types before `=` sign
+  #     #
+  #     # Default: true
+  #     break_single_constructors: true
+  #
+  #     # Whether or not to curry constraints on function.
+  #     #
+  #     # E.g: @allValues :: Enum a => Bounded a => Proxy a -> [a]@
+  #     #
+  #     # Instead of @allValues :: (Enum a, Bounded a) => Proxy a -> [a]@
+  #     #
+  #     # Default: false
+  #     curried_context: false
+
+  # Align the right hand side of some elements.  This is quite conservative
+  # and only applies to statements where each element occupies a single
+  # line.
+  # Possible values:
+  # - always - Always align statements.
+  # - adjacent - Align statements that are on adjacent lines in groups.
+  # - never - Never align statements.
+  # All default to always.
+  - simple_align:
+      cases: always
+      top_level_patterns: always
+      records: always
+      multi_way_if: always
+
+  # Import cleanup
+  - imports:
+      # There are different ways we can align names and lists.
+      #
+      # - global: Align the import names and import list throughout the entire
+      #   file.
+      #
+      # - file: Like global, but don't add padding when there are no qualified
+      #   imports in the file.
+      #
+      # - group: Only align the imports per group (a group is formed by adjacent
+      #   import lines).
+      #
+      # - none: Do not perform any alignment.
+      #
+      # Default: global.
+      align: global
+
+      # The following options affect only import list alignment.
+      #
+      # List align has following options:
+      #
+      # - after_alias: Import list is aligned with end of import including
+      #   'as' and 'hiding' keywords.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                          init, last, length)
+      #
+      # - with_alias: Import list is aligned with start of alias or hiding.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                 init, last, length)
+      #
+      # - with_module_name: Import list is aligned `list_padding` spaces after
+      #   the module name.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #                          init, last, length)
+      #
+      #   This is mainly intended for use with `pad_module_names: false`.
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, head,
+      #                          init, last, length, scanl, scanr, take, drop,
+      #                          sort, nub)
+      #
+      # - new_line: Import list starts always on new line.
+      #
+      #   > import qualified Data.List      as List
+      #   >     (concat, foldl, foldr, head, init, last, length)
+      #
+      # - repeat: Repeat the module name to align the import list.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head)
+      #   > import qualified Data.List      as List (init, last, length)
+      #
+      # Default: after_alias
+      list_align: after_alias
+
+      # Right-pad the module names to align imports in a group:
+      #
+      # - true: a little more readable
+      #
+      #   > import qualified Data.List       as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # - false: diff-safe
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, init,
+      #   >                                     last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # Default: true
+      pad_module_names: false
+
+      # Long list align style takes effect when import is too long. This is
+      # determined by 'columns' setting.
+      #
+      # - inline: This option will put as much specs on same line as possible.
+      #
+      # - new_line: Import list will start on new line.
+      #
+      # - new_line_multiline: Import list will start on new line when it's
+      #   short enough to fit to single line. Otherwise it'll be multiline.
+      #
+      # - multiline: One line per import list entry.
+      #   Type with constructor list acts like single import.
+      #
+      #   > import qualified Data.Map as M
+      #   >     ( empty
+      #   >     , singleton
+      #   >     , ...
+      #   >     , delete
+      #   >     )
+      #
+      # Default: inline
+      long_list_align: inline
+
+      # Align empty list (importing instances)
+      #
+      # Empty list align has following options
+      #
+      # - inherit: inherit list_align setting
+      #
+      # - right_after: () is right after the module name:
+      #
+      #   > import Vector.Instances ()
+      #
+      # Default: inherit
+      empty_list_align: right_after
+
+      # List padding determines indentation of import list on lines after import.
+      # This option affects 'long_list_align'.
+      #
+      # - <integer>: constant value
+      #
+      # - module_name: align under start of module name.
+      #   Useful for 'file' and 'group' align settings.
+      #
+      # Default: 4
+      list_padding: 4
+
+      # Separate lists option affects formatting of import list for type
+      # or class. The only difference is single space between type and list
+      # of constructors, selectors and class functions.
+      #
+      # - true: There is single space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable (fold, foldl, foldMap))
+      #
+      # - false: There is no space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable(fold, foldl, foldMap))
+      #
+      # Default: true
+      separate_lists: true
+
+      # Space surround option affects formatting of import lists on a single
+      # line. The only difference is single space after the initial
+      # parenthesis and a single space before the terminal parenthesis.
+      #
+      # - true: There is single space associated with the enclosing
+      #   parenthesis.
+      #
+      #   > import Data.Foo ( foo )
+      #
+      # - false: There is no space associated with the enclosing parenthesis
+      #
+      #   > import Data.Foo (foo)
+      #
+      # Default: false
+      space_surround: false
+
+      # Post qualify option moves any qualifies found in import declarations
+      # to the end of the declaration. This also adjust padding for any
+      # unqualified import declarations.
+      #
+      # - true: Qualified as <module name> is moved to the end of the
+      #   declaration.
+      #
+      #   > import Data.Bar
+      #   > import Data.Foo qualified as F
+      #
+      # - false: Qualified remains in the default location and unqualified
+      #   imports are padded to align with qualified imports.
+      #
+      #   > import           Data.Bar
+      #   > import qualified Data.Foo as F
+      #
+      # Default: false
+      post_qualify: false
+
+      # Automatically group imports based on their module names, with
+      # a blank line separating each group. Groups are ordered in
+      # alphabetical order.
+      #
+      # By default, this groups by the first part of each module's
+      # name (Control.* will be grouped together, Data.*... etc), but
+      # this can be configured with the group_patterns setting.
+      #
+      # When enabled, this rewrites existing blank lines and groups.
+      #
+      # - true: Group imports by the first part of the module name.
+      #
+      #   > import Control.Applicative
+      #   > import Control.Monad
+      #   > import Control.Monad.MonadError
+      #   >
+      #   > import Data.Functor
+      #
+      # - false: Keep import groups as-is (still sorting and
+      #   formatting the imports within each group)
+      #
+      #   > import Control.Monad
+      #   > import Data.Functor
+      #   >
+      #   > import Control.Applicative
+      #   > import Control.Monad.MonadError
+      #
+      # Default: false
+      group_imports: false
+
+      # A list of rules specifying how to group modules and how to
+      # order the groups.
+      #
+      # Each rule has a match field; the rule only applies to module
+      # names matched by this pattern. Patterns are POSIX extended
+      # regular expressions; see the documentation of Text.Regex.TDFA
+      # for details:
+      # https://hackage.haskell.org/package/regex-tdfa-1.3.1.2/docs/Text-Regex-TDFA.html
+      #
+      # Rules are processed in order, so only the *first* rule that
+      # matches a specific module will apply. Any module names that do
+      # not match a single rule will be put into a single group at the
+      # end of the import block.
+      #
+      # Example: group MyApp modules first, with everything else in
+      # one group at the end.
+      #
+      #  group_rules:
+      #    - match: "^MyApp\\>"
+      #
+      #  > import MyApp
+      #  > import MyApp.Foo
+      #  >
+      #  > import Control.Monad
+      #  > import MyApps
+      #  > import Test.MyApp
+      #
+      # A rule can also optionally have a sub_group pattern. Imports
+      # that match the rule will be broken up into further groups by
+      # the part of the module name matched by the sub_group pattern.
+      #
+      # Example: group MyApp modules first, then everything else
+      # sub-grouped by the first part of the module name.
+      #
+      #  group_rules:
+      #    - match: "^MyApp\\>"
+      #    - match: "."
+      #      sub_group: "^[^.]+"
+      #
+      #  > import MyApp
+      #  > import MyApp.Foo
+      #  >
+      #  > import Control.Applicative
+      #  > import Control.Monad
+      #  >
+      #  > import Data.Map
+      #
+      # A pattern only needs to match part of the module name, which
+      # could be in the middle. You can use ^pattern to anchor to the
+      # beginning of the module name, pattern$ to anchor to the end
+      # and ^pattern$ to force a full match. Example:
+      #
+      #  - "Test\\." would match "Test.Foo" and "Foo.Test.Lib"
+      #  - "^Test\\." would match "Test.Foo" but not "Foo.Test.Lib"
+      #  - "\\.Test$" would match "Foo.Test" but not "Foo.Test.Lib"
+      #  - "^Test$" would *only* match "Test"
+      #
+      # You can use \\< and \\> to anchor against the beginning and
+      # end of words, respectively. For example:
+      #
+      #  - "^Test\\." would match "Test.Foo" but not "Test" or "Tests"
+      #  - "^Test\\>" would match "Test.Foo" and "Test", but not
+      #    "Tests"
+      #
+      # The default is a single rule that matches everything and
+      # sub-groups based on the first component of the module name.
+      #
+      # Default: [{ "match" : ".*", "sub_group": "^[^.]+" }]
+      group_rules:
+        - match: ".*"
+          sub_group: "^[^.]+"
+
+  # Language pragmas
+  - language_pragmas:
+      # We can generate different styles of language pragma lists.
+      #
+      # - vertical: Vertical-spaced language pragmas, one per line.
+      #
+      # - compact: A more compact style.
+      #
+      # - compact_line: Similar to compact, but wrap each line with
+      #   `{-# LANGUAGE #-}'.
+      #
+      # - vertical_compact: Similar to vertical, but use only one language pragma.
+      #
+      # Default: vertical.
+      style: vertical
+
+      # Align affects alignment of closing pragma brackets.
+      #
+      # - true: Brackets are aligned in same column.
+      #
+      # - false: Brackets are not aligned together. There is only one space
+      #   between actual import and closing bracket.
+      #
+      # Default: true
+      align: true
+
+      # stylish-haskell can detect redundancy of some language pragmas. If this
+      # is set to true, it will remove those redundant pragmas. Default: true.
+      remove_redundant: true
+
+      # Language prefix to be used for pragma declaration, this allows you to
+      # use other options non case-sensitive like "language" or "Language".
+      # If a non correct String is provided, it will default to: LANGUAGE.
+      language_prefix: LANGUAGE
+
+  # Replace tabs by spaces. This is disabled by default.
+  # - tabs:
+  #     # Number of spaces to use for each tab. Default: 8, as specified by the
+  #     # Haskell report.
+  #     spaces: 8
+
+  # Remove trailing whitespace
+  - trailing_whitespace: {}
+
+  # Squash multiple spaces between the left and right hand sides of some
+  # elements into single spaces. Basically, this undoes the effect of
+  # simple_align but is a bit less conservative.
+  # - squash: {}
+
+# A common setting is the number of columns (parts of) code will be wrapped
+# to. Different steps take this into account.
+#
+# Set this to null to disable all line wrapping.
+#
+# Default: 80.
+columns: 80
+
+# By default, line endings are converted according to the OS. You can override
+# preferred format here.
+#
+# - native: Native newline format. CRLF on Windows, LF on other OSes.
+#
+# - lf: Convert to LF ("\n").
+#
+# - crlf: Convert to CRLF ("\r\n").
+#
+# Default: native.
+newline: native
+
+# Sometimes, language extensions are specified in a cabal file or from the
+# command line instead of using language pragmas in the file. stylish-haskell
+# needs to be aware of these, so it can parse the file correctly.
+#
+# No language extensions are enabled by default.
+# language_extensions:
+  # - TemplateHaskell
+  # - QuasiQuotes
+
+# Attempt to find the cabal file in ancestors of the current directory, and
+# parse options (currently only language extensions) from that.
+#
+# Default: true
+cabal: true

--- a/README.md
+++ b/README.md
@@ -30,3 +30,12 @@ Usage of this library is documented in `Language.Purescript.Bridge`, with `write
 ## Status
 
 It works for my use case and is used in production. PRs for more `PSType`s definitions and bridges are very welcome! 
+
+## Contributing
+
+### Formatting the source code
+
+This repo uses [`stylish-haskell`](https://github.com/haskell/stylish-haskell). `.stylish-haskell.yaml` is provided.
+```
+find . -name '*.hs' | xargs stylish-haskell -i
+```

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,2 @@
-import Distribution.Simple
+import           Distribution.Simple
 main = defaultMain

--- a/example/app/GeneratePurescript.hs
+++ b/example/app/GeneratePurescript.hs
@@ -1,7 +1,7 @@
 module Main where
 
 import           Control.Lens
-import           Data.Text                                  (pack)
+import           Data.Text (pack)
 import           Language.PureScript.Bridge
 import           Language.PureScript.Bridge.CodeGenSwitches (ForeignOptions (ForeignOptions),
                                                              genForeign,

--- a/example/app/Setup.hs
+++ b/example/app/Setup.hs
@@ -1,2 +1,2 @@
-import Distribution.Simple
+import           Distribution.Simple
 main = defaultMain

--- a/example/src/MyLib.hs
+++ b/example/src/MyLib.hs
@@ -6,21 +6,21 @@ module MyLib (main) where
 
 import           Prelude
 
-import           Control.Lens               (view)
-import           Control.Monad.IO.Class     (liftIO)
+import           Control.Lens (view)
+import           Control.Monad.IO.Class (liftIO)
 import           Data.Aeson
-import qualified Data.Aeson.Encode.Pretty   as AP
+import qualified Data.Aeson.Encode.Pretty as AP
 import qualified Data.ByteString.Lazy.Char8 as Char8
-import qualified Data.Map.Lazy              as Map
-import           Data.Text                  (pack, unpack)
+import qualified Data.Map.Lazy as Map
+import           Data.Text (pack, unpack)
 import           GHC.Generics
 import           GHC.TypeLits
 import           Network.Wai.Handler.Warp
 import           Servant
-import           System.Environment         (lookupEnv)
+import           System.Environment (lookupEnv)
 
-import           Types                      (Baz (Baz), Foo (Foo), fooList,
-                                             fooMap, fooMessage, fooNumber)
+import           Types (Baz (Baz), Foo (Foo), fooList, fooMap, fooMessage,
+                        fooNumber)
 
 type FooServer
   = "foo" :> (Get '[JSON] Foo

--- a/example/src/Types.hs
+++ b/example/src/Types.hs
@@ -7,9 +7,9 @@
 
 module Types where
 
-import           Control.Lens.TH                    (makeLenses)
+import           Control.Lens.TH (makeLenses)
 import           Data.Aeson
-import qualified Data.Map.Lazy                      as Map
+import qualified Data.Map.Lazy as Map
 import           Data.Proxy
 import           Data.Text
 import           GHC.Generics

--- a/src/Language/PureScript/Bridge.hs
+++ b/src/Language/PureScript/Bridge.hs
@@ -12,18 +12,18 @@ module Language.PureScript.Bridge (
 
 
 import           Control.Applicative
-import qualified Data.Map                              as M
-import qualified Data.Set                              as Set
-import qualified Data.Text.IO                          as T
+import qualified Data.Map as M
+import qualified Data.Set as Set
+import qualified Data.Text.IO as T
 
 
-import           Language.PureScript.Bridge.Builder         as Bridge
-import           Language.PureScript.Bridge.Primitives      as Bridge
-import           Language.PureScript.Bridge.Printer         as Bridge
-import           Language.PureScript.Bridge.SumType         as Bridge
-import           Language.PureScript.Bridge.Tuple           as Bridge
-import           Language.PureScript.Bridge.TypeInfo        as Bridge
+import           Language.PureScript.Bridge.Builder as Bridge
 import           Language.PureScript.Bridge.CodeGenSwitches as Switches
+import           Language.PureScript.Bridge.Primitives as Bridge
+import           Language.PureScript.Bridge.Printer as Bridge
+import           Language.PureScript.Bridge.SumType as Bridge
+import           Language.PureScript.Bridge.Tuple as Bridge
+import           Language.PureScript.Bridge.TypeInfo as Bridge
 
 -- | Your entry point to this library and quite likely all you will need.
 --   Make sure all your types derive `Generic` and `Typeable`.

--- a/src/Language/PureScript/Bridge/Builder.hs
+++ b/src/Language/PureScript/Bridge/Builder.hs
@@ -37,14 +37,12 @@ module Language.PureScript.Bridge.Builder (
 
 import           Control.Applicative
 import           Control.Lens
-import           Control.Monad                       (MonadPlus, guard, mplus,
-                                                      mzero)
+import           Control.Monad (MonadPlus, guard, mplus, mzero)
 import           Control.Monad.Reader.Class
-import           Control.Monad.Trans.Reader          (Reader, ReaderT (..),
-                                                      runReader)
-import           Data.Maybe                          (fromMaybe)
+import           Control.Monad.Trans.Reader (Reader, ReaderT (..), runReader)
+import           Data.Maybe (fromMaybe)
 import           Data.Monoid ((<>))
-import qualified Data.Text                           as T
+import qualified Data.Text as T
 import           Language.PureScript.Bridge.TypeInfo
 
 newtype BridgeBuilder a =

--- a/src/Language/PureScript/Bridge/CodeGenSwitches.hs
+++ b/src/Language/PureScript/Bridge/CodeGenSwitches.hs
@@ -1,5 +1,5 @@
 -- | General switches for the code generation, such as generating profunctor-lenses or not
-module Language.PureScript.Bridge.CodeGenSwitches 
+module Language.PureScript.Bridge.CodeGenSwitches
     ( Settings (..)
     , ForeignOptions(..)
     , defaultSettings
@@ -13,14 +13,14 @@ module Language.PureScript.Bridge.CodeGenSwitches
     ) where
 
 
-import Data.Monoid (Endo(..))
+import           Data.Monoid (Endo (..))
 
 -- | General settings for code generation
 data Settings = Settings
-    { generateLenses :: Bool -- ^use purescript-profunctor-lens for generated PS-types?
-    , genericsGenRep :: Bool -- ^generate generics using purescript-generics-rep instead of purescript-generics
+    { generateLenses         :: Bool -- ^use purescript-profunctor-lens for generated PS-types?
+    , genericsGenRep         :: Bool -- ^generate generics using purescript-generics-rep instead of purescript-generics
     , generateArgonautCodecs :: Bool -- ^generate Data.Argonaut.Decode.Class EncodeJson and DecodeJson instances
-    , generateForeign :: Maybe ForeignOptions -- ^generate Foreign.Generic Encode and Decode instances
+    , generateForeign        :: Maybe ForeignOptions -- ^generate Foreign.Generic Encode and Decode instances
     }
     deriving (Eq, Show)
 

--- a/src/Language/PureScript/Bridge/PSTypes.hs
+++ b/src/Language/PureScript/Bridge/PSTypes.hs
@@ -7,9 +7,9 @@
 -- | PureScript types to be used for bridges, e.g. in "Language.PureScript.Bridge.Primitives".
 module Language.PureScript.Bridge.PSTypes where
 
-import           Control.Lens                        (views)
-import qualified Data.Text                           as T
+import           Control.Lens (views)
 import           Control.Monad.Reader.Class
+import qualified Data.Text as T
 
 
 import           Language.PureScript.Bridge.Builder

--- a/src/Language/PureScript/Bridge/Primitives.hs
+++ b/src/Language/PureScript/Bridge/Primitives.hs
@@ -1,16 +1,16 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE DataKinds #-}
 
 
 module Language.PureScript.Bridge.Primitives where
 
 
+import           Control.Monad.Reader.Class
 import           Data.Proxy
 import           Language.PureScript.Bridge.Builder
 import           Language.PureScript.Bridge.PSTypes
 import           Language.PureScript.Bridge.TypeInfo
-import           Control.Monad.Reader.Class
 
 
 boolBridge :: BridgePart

--- a/src/Language/PureScript/Bridge/Printer.hs
+++ b/src/Language/PureScript/Bridge/Printer.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE KindSignatures    #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE LambdaCase        #-}
 
 module Language.PureScript.Bridge.Printer where
 
@@ -10,9 +10,9 @@ import           Control.Lens
 import           Control.Monad
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import           Data.Maybe (isJust)
 import           Data.Monoid ((<>))
 import           Data.Set (Set)
-import           Data.Maybe (isJust)
 import qualified Data.Set as Set
 import           Data.Text (Text)
 import qualified Data.Text as T
@@ -20,9 +20,9 @@ import qualified Data.Text.IO as T
 import           System.Directory
 import           System.FilePath
 
+import qualified Language.PureScript.Bridge.CodeGenSwitches as Switches
 import           Language.PureScript.Bridge.SumType
 import           Language.PureScript.Bridge.TypeInfo
-import qualified Language.PureScript.Bridge.CodeGenSwitches as Switches
 
 
 data Module (lang :: Language) = PSModule {
@@ -112,7 +112,7 @@ _argonautCodecsImports settings
 
 _foreignImports :: Switches.Settings -> [ImportLine]
 _foreignImports settings
-  | (isJust . Switches.generateForeign) settings = 
+  | (isJust . Switches.generateForeign) settings =
       [ ImportLine "Foreign.Class" Nothing $ Set.fromList ["class Decode", "class Encode"]
       , ImportLine "Foreign.Generic" Nothing $ Set.fromList ["defaultOptions", "genericDecode", "genericEncode"]
       ]

--- a/src/Language/PureScript/Bridge/SumType.hs
+++ b/src/Language/PureScript/Bridge/SumType.hs
@@ -2,11 +2,11 @@
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE KindSignatures       #-}
+{-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TemplateHaskell      #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE OverloadedStrings    #-}
 
 module Language.PureScript.Bridge.SumType (
   SumType (..)

--- a/src/Language/PureScript/Bridge/Tuple.hs
+++ b/src/Language/PureScript/Bridge/Tuple.hs
@@ -3,11 +3,11 @@
 
 module Language.PureScript.Bridge.Tuple where
 
-import qualified Data.Text                           as T
+import qualified Data.Text as T
 
 
 import           Language.PureScript.Bridge.Builder
-import           Language.PureScript.Bridge.PSTypes  (psTuple)
+import           Language.PureScript.Bridge.PSTypes (psTuple)
 import           Language.PureScript.Bridge.TypeInfo
 
 
@@ -19,15 +19,15 @@ data TupleParserState =
   Start | OpenFound | ColonFound | Tuple | NoTuple deriving (Eq, Show)
 
 step :: TupleParserState -> Char -> TupleParserState
-step Start '(' = OpenFound
-step Start _ = NoTuple
-step OpenFound ',' = ColonFound
-step OpenFound _ = NoTuple
+step Start '('      = OpenFound
+step Start _        = NoTuple
+step OpenFound ','  = ColonFound
+step OpenFound _    = NoTuple
 step ColonFound ',' = ColonFound
 step ColonFound ')' = Tuple
-step ColonFound _ = NoTuple
-step Tuple _ = NoTuple
-step NoTuple _ = NoTuple
+step ColonFound _   = NoTuple
+step Tuple _        = NoTuple
+step NoTuple _      = NoTuple
 
 isTuple :: HaskellType -> Bool
 isTuple = (== Tuple) . T.foldl' step Start . _typeName

--- a/src/Language/PureScript/Bridge/TypeInfo.hs
+++ b/src/Language/PureScript/Bridge/TypeInfo.hs
@@ -26,8 +26,8 @@ module Language.PureScript.Bridge.TypeInfo (
 
 import           Control.Lens
 import           Data.Proxy
-import           Data.Text     (Text)
-import qualified Data.Text     as T
+import           Data.Text (Text)
+import qualified Data.Text as T
 import           Data.Typeable
 
 data Language = Haskell | PureScript

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -8,16 +8,15 @@
 {-# LANGUAGE TypeSynonymInstances  #-}
 
 module Main where
-import qualified Data.Map                                  as Map
-import           Data.Monoid                               ((<>))
+import qualified Data.Map as Map
+import           Data.Monoid ((<>))
 import           Data.Proxy
-import qualified Data.Text                                 as T
-import           Data.Word                                 (Word, Word64)
+import qualified Data.Text as T
+import           Data.Word (Word, Word64)
 import           Language.PureScript.Bridge
-import           Language.PureScript.Bridge.TypeParameters
 import           Language.PureScript.Bridge.CodeGenSwitches
-import           Test.Hspec                                (Spec, describe,
-                                                            hspec, it)
+import           Language.PureScript.Bridge.TypeParameters
+import           Test.Hspec (Spec, describe, hspec, it)
 import           Test.Hspec.Expectations.Pretty
 import           TestData
 
@@ -493,7 +492,7 @@ allTests = do
                           , "derive instance genericSingleProduct :: Generic SingleProduct _"
                           ]
       in recTypeText `shouldBe` txt
- 
+
   describe "tests bridging Haskells Data.Word to PureScripts Data.Word from purescript-word" $ do
     describe "moduleToText" $
       it "should contain the right import and datatype" $ do

--- a/test/TestData.hs
+++ b/test/TestData.hs
@@ -10,9 +10,9 @@
 module TestData where
 
 import           Data.Proxy
-import           Data.Text                          (Text)
+import           Data.Text (Text)
 import           Data.Typeable
-import           GHC.Generics                       (Generic)
+import           GHC.Generics (Generic)
 import           Language.PureScript.Bridge
 import           Language.PureScript.Bridge.PSTypes
 


### PR DESCRIPTION
This PR formats the whole repo with Stylish Haskell.

This repo appears to be a combination of a couple of Stylish Haskell settings. I have found Stylish Haskell settings which minimize the changes. It is mostly the same as before. All files are formatted consistently.

I am attempting to start on https://github.com/eskimor/purescript-bridge/issues/63 . The IOHK fork uses Ormolu. We can continue to use Stylish Haskell.

```
find . -name '*.hs' | xargs stylish-haskell -i
```
https://github.com/haskell/stylish-haskell/issues/162#issuecomment-380785436