### PR TITLE
update example, disable generation of `Encode` and `Decode` instances

### DIFF
--- a/example/src/Types.hs
+++ b/example/src/Types.hs
@@ -12,9 +12,11 @@ import           Data.Aeson
 import qualified Data.Map.Lazy as Map
 import           Data.Proxy
 import           Data.Text
+import           Data.Typeable
 import           GHC.Generics
 import           Language.PureScript.Bridge
 import           Language.PureScript.Bridge.PSTypes
+import           Language.PureScript.Bridge.TypeParameters (A)
 
 data Baz = Baz
   { _bazMessage :: Text
@@ -40,6 +42,15 @@ makeLenses ''Foo
 fooProxy :: Proxy Foo
 fooProxy = Proxy
 
+-- TODO newtype
+data Bar a = Bar a
+  deriving (Generic, Show, Typeable, FromJSON, ToJSON)
+
+makeLenses ''Bar
+
+barProxy :: Proxy Bar
+barProxy = Proxy
+
 myBridge :: BridgePart
 myBridge = defaultBridge
 
@@ -47,4 +58,5 @@ myTypes :: [SumType 'Haskell]
 myTypes =
   [ mkSumType (Proxy :: Proxy Baz)
   , mkSumType (Proxy :: Proxy Foo)
+  , mkSumType (Proxy :: Proxy (Bar A))
   ]

--- a/example/src/Types.purs
+++ b/example/src/Types.purs
@@ -25,10 +25,8 @@ newtype Baz =
       _bazMessage :: String
     }
 
-instance encodeBaz :: Encode Baz where
-  encode = genericEncode $ defaultOptions { unwrapSingleConstructors = false , unwrapSingleArguments = false }
-instance decodeBaz :: Decode Baz where
-  decode = genericDecode $ defaultOptions { unwrapSingleConstructors = false , unwrapSingleArguments = false }
+
+
 instance encodeJsonBaz :: EncodeJson Baz where
   encodeJson = genericEncodeAeson Argonaut.defaultOptions
 instance decodeJsonBaz :: DecodeJson Baz where
@@ -53,10 +51,8 @@ newtype Foo =
     , _fooBaz :: Baz
     }
 
-instance encodeFoo :: Encode Foo where
-  encode = genericEncode $ defaultOptions { unwrapSingleConstructors = false , unwrapSingleArguments = false }
-instance decodeFoo :: Decode Foo where
-  decode = genericDecode $ defaultOptions { unwrapSingleConstructors = false , unwrapSingleArguments = false }
+
+
 instance encodeJsonFoo :: EncodeJson Foo where
   encodeJson = genericEncodeAeson Argonaut.defaultOptions
 instance decodeJsonFoo :: DecodeJson Foo where
@@ -83,4 +79,20 @@ fooMap = _Newtype <<< prop (Proxy :: Proxy "_fooMap")
 fooBaz :: Lens' Foo Baz
 fooBaz = _Newtype <<< prop (Proxy :: Proxy "_fooBaz")
 
+--------------------------------------------------------------------------------
+newtype Bar a =
+    Bar a
+
+
+
+instance encodeJsonBar :: (Generic a ra, EncodeJson a) => EncodeJson (Bar a) where
+  encodeJson = genericEncodeAeson Argonaut.defaultOptions
+instance decodeJsonBar :: (Generic a ra, DecodeJson a, DecodeJsonField a) => DecodeJson (Bar a) where
+  decodeJson = genericDecodeAeson Argonaut.defaultOptions
+derive instance genericBar :: Generic a ra => Generic (Bar a) _
+derive instance newtypeBar :: Newtype (Bar a) _
+
+--------------------------------------------------------------------------------
+_Bar :: forall a. Iso' (Bar a) a
+_Bar = _Newtype
 --------------------------------------------------------------------------------

--- a/example/src/Types.purs
+++ b/example/src/Types.purs
@@ -4,7 +4,7 @@ module Types where
 import Data.Argonaut.Aeson.Decode.Generic (genericDecodeAeson)
 import Data.Argonaut.Aeson.Encode.Generic (genericEncodeAeson)
 import Data.Argonaut.Aeson.Options as Argonaut
-import Data.Argonaut.Decode.Class (class DecodeJson, decodeJson)
+import Data.Argonaut.Decode.Class (class DecodeJson, class DecodeJsonField, decodeJson)
 import Data.Argonaut.Encode.Class (class EncodeJson, encodeJson)
 import Data.Generic.Rep (class Generic)
 import Data.Lens (Iso', Lens', Prism', lens, prism')

--- a/src/Language/PureScript/Bridge/Printer.hs
+++ b/src/Language/PureScript/Bridge/Printer.hs
@@ -181,27 +181,27 @@ instances :: Switches.Settings -> SumType 'PureScript -> [Text]
 instances settings st@(SumType t _ is) = map go is
   where
     go :: Instance -> Text
-    go Encode =
-        "instance encode"
-            <> _typeName t
-            <> " :: "
-            <> extras
-            <> "Encode "
-            <> typeInfoToText False t
-            <> " where\n"
-            <> "  encode = genericEncode $ defaultOptions"
-            <> encodeOpts
-      where
-        encodeOpts =
-            foreignOptionsToPurescript $ Switches.generateForeign settings
-        stpLength = length sumTypeParameters
-        extras
-            | stpLength == 0 = mempty
-            | otherwise = bracketWrap constraintsInner <> " => "
-        sumTypeParameters = filter (isTypeParam t) . Set.toList $ getUsedTypes st
-        constraintsInner = T.intercalate ", " $ map instances sumTypeParameters
-        instances params = genericInstance settings params <> ", " <> encodeInstance params
-        bracketWrap x = "(" <> x <> ")"
+    go Encode = mempty
+      --   "instance encode"
+      --       <> _typeName t
+      --       <> " :: "
+      --       <> extras
+      --       <> "Encode "
+      --       <> typeInfoToText False t
+      --       <> " where\n"
+      --       <> "  encode = genericEncode $ defaultOptions"
+      --       <> encodeOpts
+      -- where
+      --   encodeOpts =
+      --       foreignOptionsToPurescript $ Switches.generateForeign settings
+      --   stpLength = length sumTypeParameters
+      --   extras
+      --       | stpLength == 0 = mempty
+      --       | otherwise = bracketWrap constraintsInner <> " => "
+      --   sumTypeParameters = filter (isTypeParam t) . Set.toList $ getUsedTypes st
+      --   constraintsInner = T.intercalate ", " $ map instances sumTypeParameters
+      --   instances params = genericInstance settings params <> ", " <> encodeInstance params
+      --   bracketWrap x = "(" <> x <> ")"
     go EncodeJson =
         "instance encodeJson"
             <> _typeName t
@@ -222,27 +222,27 @@ instances settings st@(SumType t _ is) = map go is
         constraintsInner = T.intercalate ", " $ map instances sumTypeParameters
         instances params = genericInstance settings params <> ", " <> encodeJsonInstance params
         bracketWrap x = "(" <> x <> ")"
-    go Decode =
-        "instance decode"
-            <> _typeName t
-            <> " :: "
-            <> extras
-            <> "Decode "
-            <> typeInfoToText False t
-            <> " where\n"
-            <> "  decode = genericDecode $ defaultOptions"
-            <> decodeOpts
-      where
-        decodeOpts =
-            foreignOptionsToPurescript $ Switches.generateForeign settings
-        stpLength = length sumTypeParameters
-        extras
-            | stpLength == 0 = mempty
-            | otherwise = bracketWrap constraintsInner <> " => "
-        sumTypeParameters = filter (isTypeParam t) . Set.toList $ getUsedTypes st
-        constraintsInner = T.intercalate ", " $ map instances sumTypeParameters
-        instances params = genericInstance settings params <> ", " <> decodeInstance params
-        bracketWrap x = "(" <> x <> ")"
+    go Decode = mempty
+      --   "instance decode"
+      --       <> _typeName t
+      --       <> " :: "
+      --       <> extras
+      --       <> "Decode "
+      --       <> typeInfoToText False t
+      --       <> " where\n"
+      --       <> "  decode = genericDecode $ defaultOptions"
+      --       <> decodeOpts
+      -- where
+      --   decodeOpts =
+      --       foreignOptionsToPurescript $ Switches.generateForeign settings
+      --   stpLength = length sumTypeParameters
+      --   extras
+      --       | stpLength == 0 = mempty
+      --       | otherwise = bracketWrap constraintsInner <> " => "
+      --   sumTypeParameters = filter (isTypeParam t) . Set.toList $ getUsedTypes st
+      --   constraintsInner = T.intercalate ", " $ map instances sumTypeParameters
+      --   instances params = genericInstance settings params <> ", " <> decodeInstance params
+      --   bracketWrap x = "(" <> x <> ")"
     go DecodeJson =
         "instance decodeJson"
             <> _typeName t


### PR DESCRIPTION
This PR:
- improves the example
- includes `DecodeJsonField` https://github.com/eskimor/purescript-bridge/commit/c55622e325a422fbfc2101b0ed31d882fc55ceaf in the example
- disables a feature which is partially broken

Previously, the example did not include any data type with a type parameter, which the unit tests have.

Haskell:
```
data Bar a = Bar a
  deriving (Generic, Show, Typeable, FromJSON, ToJSON)

makeLenses ''Bar

barProxy :: Proxy Bar
barProxy = Proxy
```

Adding this to the example has exposed a partially-broken feature.

The generated PureScript produces a compilation error:
```
newtype Bar a =
    Bar a

instance encodeBar :: (Generic a ra, Encode a) => Encode (Bar a) where
  encode = genericEncode $ defaultOptions { unwrapSingleConstructors = false , unwrapSingleArguments = false }
instance decodeBar :: (Generic a ra, Decode a) => Decode (Bar a) where
  decode = genericDecode $ defaultOptions { unwrapSingleConstructors = false , unwrapSingleArguments = false }
instance encodeJsonBar :: (Generic a ra, EncodeJson a) => EncodeJson (Bar a) where
  encodeJson = genericEncodeAeson Argonaut.defaultOptions
instance decodeJsonBar :: (Generic a ra, DecodeJson a, DecodeJsonField a) => DecodeJson (Bar a) where
  decodeJson = genericDecodeAeson Argonaut.defaultOptions
derive instance genericBar :: Generic a ra => Generic (Bar a) _
derive instance newtypeBar :: Newtype (Bar a) _

--------------------------------------------------------------------------------
_Bar :: forall a. Iso' (Bar a) a
_Bar = _Newtype

```

The `encodeBar` and `decodeBar` instances fail to build:

```
spago build 
[1 of 2] Compiling Types
Error found:
in module Types
at src/Types.purs:91:12 - 91:25 (line 91, column 12 - line 91, column 25)

  No type class instance was found for
                                              
    Foreign.Generic.Class.EncodeWithOptions a2
                                              
  The following instance partially overlaps the above constraint, which means the rest of its instance chain will not be considered:

    Foreign.Generic.Class.encodeWithOptionsRecord


while solving type class constraint
                                                       
  Foreign.Generic.Class.GenericEncodeArgs (Argument a2)
                                                       
while checking that type forall (a :: Type) (rep :: Type).                                            
                           Generic a rep => GenericEncode rep => { fieldTransform :: String -> String 
                                                                 , sumEncoding :: SumEncoding         
                                                                 , unwrapSingleArguments :: Boolean   
                                                                 , unwrapSingleConstructors :: Boolean
                                                                 }                                    
                                                                 -> a -> Foreign                      
  is at least as general as type t0 -> t1
while checking that expression genericEncode
  has type t0 -> t1
in value declaration encodeBar

where a2 is a rigid type variable
        bound at (line 0, column 0 - line 0, column 0)
      t0 is an unknown type
      t1 is an unknown type

See https://github.com/purescript/documentation/blob/master/errors/NoInstanceFound.md for more information,
or to contribute content related to this error.


[error] Failed to build.
```

Consequently, I have disabled the generators for the `Encode` and `Decode` instances. `EncodeJson` and `DecodeJson` still work fine.

I think it is easiest to fix or replace `Encode` and `Decode` in https://github.com/eskimor/purescript-bridge/pull/77
