### PR TITLE
Feature: generic `Show`

### DIFF
--- a/src/Language/PureScript/Bridge/SumType.hs
+++ b/src/Language/PureScript/Bridge/SumType.hs
@@ -25,6 +25,7 @@ module Language.PureScript.Bridge.SumType
     , sumTypeConstructors
     , recLabel
     , recValue
+    , showing
     ) where
 
 import           Control.Lens hiding (from, to)
@@ -89,6 +90,9 @@ equal _ (SumType ti dc is) = SumType ti dc . nub $ Eq : is
 -- | Ensure that both `Eq` and `Ord` instances are generated for your type.
 order :: Ord a => Proxy a -> SumType t -> SumType t
 order _ (SumType ti dc is) = SumType ti dc . nub $ Eq : Ord : is
+
+showing :: Show a => Proxy a -> SumType t -> SumType t
+showing _ (SumType ti dc is) = SumType ti dc . nub $ Show : is
 
 data DataConstructor (lang :: Language) = DataConstructor
   { _sigConstructor :: !Text

--- a/src/Language/PureScript/Bridge/SumType.hs
+++ b/src/Language/PureScript/Bridge/SumType.hs
@@ -66,7 +66,7 @@ mkSumType p = SumType (mkTypeInfo p) constructors (Encode : Decode : EncodeJson 
     constructors = gToConstructors (from (undefined :: t))
 
 -- | Purescript typeclass instances that can be generated for your Haskell types.
-data Instance = Encode | EncodeJson | Decode | DecodeJson | Generic | Newtype | Eq | Ord
+data Instance = Encode | EncodeJson | Decode | DecodeJson | Generic | Newtype | Eq | Ord | Show
   deriving (Eq, Show)
 
 {- | The Purescript typeclass `Newtype` might be derivable if the original

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -39,7 +39,7 @@ allTests = do
              in bst `shouldBe` ti
         it "tests with custom type Foo" $
             let prox = Proxy :: Proxy Foo
-                bst = bridgeSumType (buildBridge defaultBridge) (order prox $ mkSumType prox)
+                bst = bridgeSumType (buildBridge defaultBridge) (showing prox . order prox $ mkSumType prox)
                 st =
                     SumType
                         TypeInfo {_typePackage = "", _typeModule = "TestData", _typeName = "Foo", _typeParameters = []}
@@ -57,11 +57,11 @@ allTests = do
                                     ]
                             }
                         ]
-                        [Eq, Ord, Encode, Decode, EncodeJson, DecodeJson, Generic]
+                        [Show, Eq, Ord, Encode, Decode, EncodeJson, DecodeJson, Generic]
              in bst `shouldBe` st
         it "tests generation of for custom type Foo" $
             let prox = Proxy :: Proxy Foo
-                recType = bridgeSumType (buildBridge defaultBridge) (order prox $ mkSumType prox)
+                recType = bridgeSumType (buildBridge defaultBridge) (showing prox . order prox $ mkSumType prox)
                 recTypeText = sumTypeToText defaultSettings recType
                 txt =
                     T.stripEnd $
@@ -70,6 +70,9 @@ allTests = do
                             , "    Foo"
                             , "  | Bar Int"
                             , "  | FooBar Int String"
+                            , ""
+                            , "instance showFoo ∷ Show Foo where"
+                            , "  show value = genericShow value"
                             , ""
                             , "derive instance eqFoo :: Eq Foo"
                             , "derive instance ordFoo :: Ord Foo"


### PR DESCRIPTION
This feature was requested in #40 and later in #78 but was never implemented. Maybe owing to `Show` not being a derivable type class in PureScript. However, for types that are instances of `Generic` there is `genericShow` in the standard library, so I am wielding that.

Thanks to Colin @fosskers for blazing the trail.

Closes #78, ping @flip111.