### PR TITLE
Export `GDataConstructor`.

### DIFF
--- a/src/Language/PureScript/Bridge/SumType.hs
+++ b/src/Language/PureScript/Bridge/SumType.hs
@@ -14,6 +14,7 @@ module Language.PureScript.Bridge.SumType
     , equal
     , order
     , DataConstructor (..)
+    , GDataConstructor
     , RecordEntry (..)
     , Instance (..)
     , nootype


### PR DESCRIPTION
Why, because it is exposed in the type signature of `mkSumType`. So it must be mentioned in the constraints of any polymorphic function that does somethnig with `mkSumType`.

Example:

```Haskell
makeType :: forall thing. _ => SumType Haskell
makeType = mkSumType (Proxy @thing)
```

Without this patch, there is no way to fill in the blank!