### PR TITLE
Support for GHC>=9.6

### DIFF
--- a/src/Language/PureScript/Bridge/Primitives.hs
+++ b/src/Language/PureScript/Bridge/Primitives.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -30,7 +31,11 @@ doubleBridge :: BridgePart
 doubleBridge = typeName ^== "Double" >> return psNumber
 
 listBridge :: BridgePart
+#if __GLASGOW_HASKELL__>=906
+listBridge = typeName ^== "List" >> psArray
+#else
 listBridge = typeName ^== "[]" >> psArray
+#endif
 
 maybeBridge :: BridgePart
 maybeBridge = typeName ^== "Maybe" >> psMaybe


### PR DESCRIPTION
Adjust for renaming of List-type in `GHC.List` 