### PR TITLE
Support GHC.Tuple.Prim.Tuple2

### DIFF
--- a/src/Language/PureScript/Bridge/Tuple.hs
+++ b/src/Language/PureScript/Bridge/Tuple.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -10,7 +11,11 @@ import           Language.PureScript.Bridge.PSTypes (psTuple)
 import           Language.PureScript.Bridge.TypeInfo
 
 tupleBridge :: BridgePart
+#if __GLASGOW_HASKELL__>=908
+tupleBridge = typeName ^== "Tuple2" >> psTuple
+#else
 tupleBridge = doCheck haskType isTuple >> psTuple
+#endif
 
 data TupleParserState = Start | OpenFound | ColonFound | Tuple | NoTuple
   deriving (Eq, Show)


### PR DESCRIPTION
I'm not 100% sure when Tuple2 type-representation has changed.
But aligning to work with ghc-9.8.2 with the same style as #90 .

context: I was [rebuilding the bridge for my blog engine and I happen to use tuples](https://github.com/kitchensink-tech/kitchensink/pull/1/files), in that diff what matters is the absence of spurious diff on the `purs/kitchen-sink-compat/src/KitchenSink/Layout/Blog/Summary.purs` path